### PR TITLE
WIP: wrapIdentifier and postProcessResponse knex hooks

### DIFF
--- a/hooks-spike.js
+++ b/hooks-spike.js
@@ -1,0 +1,38 @@
+/* eslint-disable no-console */
+const knex = require('test/lib/knex');
+
+knex.client.config.wrapIdentifier = (value, wrap) => {
+  console.log('wrapping', value, 'to', wrap(value));
+  return wrap(value);
+};
+
+knex.client.config.postProcessResponse = (response, builder) => {
+  console.log();
+  console.log('post processing', response);
+  console.log();
+  console.log('builder', builder);
+  return response;
+};
+
+const query = table => {
+  const builder = knex(table);
+  builder._knormModel = 'the model';
+  return builder;
+};
+
+const func = async () => {
+  await knex.schema.createTableIfNotExists('foo', table => table.string('bar'));
+  const ret = await query('foo')
+    .returning('*')
+    .insert({ bar: 'bar' });
+
+  await query('foo').select();
+  await knex.schema.dropTableIfExists('foo');
+
+  return ret;
+};
+
+func()
+  .then(console.log)
+  .catch(console.log)
+  .then(process.exit);

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^4.7.2",
     "eslint-config-prettier": "^2.6.0",
     "eslint-plugin-prettier": "^2.3.1",
-    "knex": "^0.13.0",
+    "knex": "github:tgriesser/knex#master",
     "knorm-postgres": "^2.0.0",
     "mocha": "^3.2.0",
     "npm-run-all": "^4.0.2",


### PR DESCRIPTION
`wrapIdentifier` for fieldName => columnName conversion
`postProcessResponse` to centralise instance creation, population and value-casting

can't use these yet due to lacking context https://github.com/tgriesser/knex/issues/2268
for the time being, https://github.com/tgriesser/knex/pull/2227 could work for knorm but suffers the same limitation, having to overload all query methods.