### PR TITLE
feat: upgrade sql-bricks dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "proxyquire": "2.1.3",
     "rimraf": "3.0.2",
     "sinon": "9.0.2",
-    "sql-bricks-postgres": "0.5.0",
+    "sql-bricks-postgres": "0.6.0",
     "ts-node": "8.9.0",
     "tsconfig-paths": "3.9.0",
     "typescript": "3.8.3",

--- a/packages/knorm/package.json
+++ b/packages/knorm/package.json
@@ -26,7 +26,7 @@
   ],
   "dependencies": {
     "lodash": "^4.17.5",
-    "sql-bricks": "^2.0.4",
+    "sql-bricks": "^3.0.1",
     "validator": "^13.0.0"
   },
   "repository": {

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -37,6 +37,6 @@
   "dependencies": {
     "pg": "^8.0.0",
     "pg-connection-string": "^2.0.0",
-    "sql-bricks-postgres": "^0.5.0"
+    "sql-bricks-postgres": "^0.6.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11877,20 +11877,18 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-sql-bricks-postgres@0.5.0, sql-bricks-postgres@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/sql-bricks-postgres/-/sql-bricks-postgres-0.5.0.tgz#d77598d5b16d0fa3b1ab4b89bc8d679af4dcc0a4"
-  integrity sha512-HaE7o89JU5GIZfs53DBIJgs2rVpIj/HisPhr6jRyILqPy505xlEmsvVZVZmXKVaGxqwuxNM+R71owaPBMK0cGQ==
+sql-bricks-postgres@0.6.0, sql-bricks-postgres@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/sql-bricks-postgres/-/sql-bricks-postgres-0.6.0.tgz#111708cdd6ad6340ccedddba5f0ea39d9fb56b20"
+  integrity sha512-JbStbgWRWSV9pOnJLjBUzgFT4z3n2e90IyZsCCMLa/bYBg3uIyd8Uawk567gt4b25TRKDdX91+ru5SneCqeMgA==
   dependencies:
-    sql-bricks "^2"
+    sql-bricks "^3"
     underscore "^1.4.x"
 
-sql-bricks@^2, sql-bricks@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/sql-bricks/-/sql-bricks-2.0.4.tgz#14ba0d7373977eced37f847f0a1017008350c444"
-  integrity sha512-H5E+5i0XgNzdihovSABpk1G4kOoxaQTQzYlhWefsiVhR9/bXrsC91DTG/NcTQ9E/JSjC7L9WNe8A5+3dfCwdtA==
-  dependencies:
-    underscore "1.4.x"
+sql-bricks@^3, sql-bricks@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/sql-bricks/-/sql-bricks-3.0.1.tgz#14938fabef1f9683c12b0284d39dad5a5c601bfe"
+  integrity sha512-ZkU/R+bwf7d9FxlwMJp/31P5bluVCjUuftutkqJjQKH1QMCE1iaEc0xeY0aVepc38fxC+ljUrqausGCzzcHzHQ==
 
 sshpk@^1.7.0:
   version "1.16.1"
@@ -12656,11 +12654,6 @@ unc-path-regex@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
-
-underscore@1.4.x:
-  version "1.4.4"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.4.4.tgz#61a6a32010622afa07963bf325203cf12239d604"
-  integrity sha1-YaajIBBiKvoHljvzJSA88SI51gQ=
 
 underscore@^1.4.x:
   version "1.9.2"


### PR DESCRIPTION
This PR upgrades the `sql-bricks` and `sql-bricks-postgres` packages.

The `sql-bricks` package was upgraded to a breaking change version. The change was a drop of compatibility with Node versions before 4.x (see https://github.com/CSNW/sql-bricks/commit/b7aed22528ded091a5878fdc840659248f5f3936)

The main motivator for this upgrade is to upgrade the imported underscore packages, which have a CVE entry for the current sql-bricks pacakges https://nvd.nist.gov/vuln/detail/CVE-2021-23358